### PR TITLE
Improved error handling to avoid database-inconsistency.

### DIFF
--- a/Sources/PerfectLocalAuthentication/Schema/InitializeSchema.swift
+++ b/Sources/PerfectLocalAuthentication/Schema/InitializeSchema.swift
@@ -13,44 +13,39 @@ import PerfectSessionPostgreSQL
 
 public func initializeSchema(_ fname: String = "./config/ApplicationConfiguration.json") -> [String:Any] {
 	var opts = [String:Any]()
-	if let config = JSONConfig(name: fname) {
-		let dict = config.getValues()!
-		opts["httpPort"] = dict["httpport"] as! Int
-		// StORM Connector Config
-		PostgresConnector.host        = dict["postgreshost"] as? String ?? ""
-		PostgresConnector.username    = dict["postgresuser"] as? String ?? ""
-		PostgresConnector.password    = dict["postgrespwd"] as? String ?? ""
-		PostgresConnector.database    = dict["postgresdbname"] as? String ?? ""
-		PostgresConnector.port        = dict["postgresport"] as? Int ?? 0
 
-		// Outbound email config
-		SMTPConfig.mailserver         = dict["mailserver"] as? String ?? ""
-		SMTPConfig.mailuser			  = dict["mailuser"] as? String ?? ""
-		SMTPConfig.mailpass			  = dict["mailpass"] as? String ?? ""
-		SMTPConfig.mailfromaddress    = dict["mailfromaddress"] as? String ?? ""
-		SMTPConfig.mailfromname        = dict["mailfromname"] as? String ?? ""
-
-		opts["baseURL"] = dict["baseURL"] as? String ?? ""
-		AuthenticationVariables.baseURL = dict["baseURL"] as? String ?? ""
-
-		// session driver config
-		PostgresSessionConnector.host = PostgresConnector.host
-		PostgresSessionConnector.port = PostgresConnector.port
-		PostgresSessionConnector.username = PostgresConnector.username
-		PostgresSessionConnector.password = PostgresConnector.password
-		PostgresSessionConnector.database = PostgresConnector.database
-		PostgresSessionConnector.table = "sessions"
-
-	} else {
-		print("Unable to get Configuration")
-
-		PostgresConnector.host        = "localhost"
-		PostgresConnector.username    = "perfect"
-		PostgresConnector.password    = "perfect"
-		PostgresConnector.database    = "perfect_testing"
-		PostgresConnector.port        = 5432
-
+	guard let config = JSONConfig(name: fname) else {
+		fatalError("Unable to open configuration file: \(fname)")
 	}
+	guard let dict = config.getValues() else {
+		fatalError("Unable to parse configuration file: \(fname)")
+	}
+
+	opts["httpPort"] = dict["httpport"] as! Int
+	// StORM Connector Config
+	PostgresConnector.host        = dict["postgreshost"] as? String ?? ""
+	PostgresConnector.username    = dict["postgresuser"] as? String ?? ""
+	PostgresConnector.password    = dict["postgrespwd"] as? String ?? ""
+	PostgresConnector.database    = dict["postgresdbname"] as? String ?? ""
+	PostgresConnector.port        = dict["postgresport"] as? Int ?? 0
+
+	// Outbound email config
+	SMTPConfig.mailserver         = dict["mailserver"] as? String ?? ""
+	SMTPConfig.mailuser			  = dict["mailuser"] as? String ?? ""
+	SMTPConfig.mailpass			  = dict["mailpass"] as? String ?? ""
+	SMTPConfig.mailfromaddress    = dict["mailfromaddress"] as? String ?? ""
+	SMTPConfig.mailfromname        = dict["mailfromname"] as? String ?? ""
+
+	opts["baseURL"] = dict["baseURL"] as? String ?? ""
+	AuthenticationVariables.baseURL = dict["baseURL"] as? String ?? ""
+
+	// session driver config
+	PostgresSessionConnector.host = PostgresConnector.host
+	PostgresSessionConnector.port = PostgresConnector.port
+	PostgresSessionConnector.username = PostgresConnector.username
+	PostgresSessionConnector.password = PostgresConnector.password
+	PostgresSessionConnector.database = PostgresConnector.database
+	PostgresSessionConnector.table = "sessions"
 
 //	StORMdebug = true
 
@@ -62,4 +57,3 @@ public func initializeSchema(_ fname: String = "./config/ApplicationConfiguratio
 
 	return opts
 }
-


### PR DESCRIPTION
The error handler in initializeSchema only set StORM's connector and may cause database-inconsistency.
Unexpected configuration may destroy databases, so I guess terminating is the best way.